### PR TITLE
feat: 저장한 풀이 페이지의 title에 문제 이름 추가

### DIFF
--- a/src/pages/newTab/solution/index.tsx
+++ b/src/pages/newTab/solution/index.tsx
@@ -15,6 +15,7 @@ const href = window.location.href;
 const selectedLanguage = href.match(languageRegex)![1];
 const problemId = href.match(problemIdRegex)![1];
 const problemName = decodeURI(href.match(problemNameRegex)![1]);
+document.title = `프로솔브 - ${problemName}`;
 
 const SolutionTabLayout = () => {
   const [isLoaded, setIsLoaded] = React.useState(true);


### PR DESCRIPTION
## 구현사항
- 저장한 풀이 페이지(new tab)의 title에 문제 이름 추가