### PR TITLE
fix: 배포 github action 수정

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,5 +1,3 @@
-name: Publish to Webstore
-
 env:
   API_KEY: ${{ secrets.API_KEY }}
   APP_ID: ${{ secrets.APP_ID }}
@@ -8,22 +6,13 @@ env:
   PROJECT_ID: ${{ secrets.PROJECT_ID }}
   STORAGE_BUCKET: ${{ secrets.STORAGE_BUCKET }}
 
+name: Publish to Webstore
 on:
-  workflow_dispatch:
-    inputs:
-      logLevel:
-        description: 'Log level'
-        required: true
-        default: 'warning'
-        type: choice
-        options:
-          - info
-          - warning
-          - debug
-      tags:
-        description: 'Test scenario tags'
-        required: false
-        type: boolean
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
 
 jobs:
   build:
@@ -43,7 +32,7 @@ jobs:
         uses: mnao305/chrome-extension-upload@3.0.0
         with:
           file-path: build.zip
-          extension-id: hogefuga(chbnbpgokeeognchnobjackjhhmhmmnd)
+          extension-id: hogefuga(pjffalefhahlellpckbbiehmbljjhihl)
           client-id: ${{ secrets.CLIENT_ID }}
           client-secret: ${{ secrets.CLIENT_SECRET }}
           refresh-token: ${{ secrets.REFRESH_TOKEN }}


### PR DESCRIPTION
## 구현 사항
- main 브랜치에서 push 이벤트 발생시 배포 (md 파일일 시 무시)
- 익스텐션 id 변경