### PR TITLE
refactor: solutionTab의 상태관련 로직들을 custom hook으로 분리

### DIFF
--- a/src/hooks/solution/useAllSolution.ts
+++ b/src/hooks/solution/useAllSolution.ts
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import { getAllSolutions } from '@src/service/solution/getAllSolutions';
+import { useIsLoaded } from '../useIsLoaded';
+
+import { SolutionResponse } from '@src/types/solution';
+import { ProblemInfo } from '@src/types/problem/problem';
+
+const useAllSolution = (problemInfo: ProblemInfo) => {
+  const { isLoaded, setIsLoaded } = useIsLoaded();
+  const [solutions, setSolutions] = React.useState<SolutionResponse>({});
+
+  React.useEffect(() => {
+    (async () => {
+      const allSolutions = await getAllSolutions(problemInfo);
+      setSolutions(allSolutions);
+      setIsLoaded(false);
+    })();
+  }, []);
+
+  return { isLoaded, solutions };
+};
+
+export { useAllSolution };

--- a/src/hooks/useIsLoaded.ts
+++ b/src/hooks/useIsLoaded.ts
@@ -1,0 +1,8 @@
+import React from 'react';
+
+const useIsLoaded = () => {
+  const [isLoaded, setIsLoaded] = React.useState(true);
+  return { isLoaded, setIsLoaded };
+};
+
+export { useIsLoaded };

--- a/src/service/solution/getAllSolutions.ts
+++ b/src/service/solution/getAllSolutions.ts
@@ -1,0 +1,31 @@
+import { SolutionResponse } from '@src/types/solution';
+
+interface HrefProps {
+  selectedLanguage: string;
+  problemId: string;
+}
+
+type GetAllSolutionFn = ({ selectedLanguage, problemId }: HrefProps) => Promise<SolutionResponse>;
+const getAllSolutions: GetAllSolutionFn = async ({ selectedLanguage, problemId }: HrefProps) => {
+  console.log(`[Pro Solve] 문제 번호:>> ${problemId} 선택한 언어:>> ${selectedLanguage}`);
+
+  const allSolutions = await new Promise<SolutionResponse>(resolve => {
+    chrome.runtime.sendMessage(
+      {
+        method: 'getAllSolutions',
+        data: {
+          problemId,
+          selectedLanguage,
+        },
+      },
+      (response: SolutionResponse) => {
+        resolve(response);
+        console.log('[Pro Solve] 풀이한 코드 List :>>', response);
+      },
+    );
+  });
+
+  return allSolutions;
+};
+
+export { getAllSolutions };

--- a/src/types/problem/problem.d.ts
+++ b/src/types/problem/problem.d.ts
@@ -1,0 +1,22 @@
+type SelectedLanguage =
+  | 'c'
+  | 'cpp'
+  | 'csharp'
+  | 'go'
+  | 'java'
+  | 'javascript'
+  | 'kotlin'
+  | 'python'
+  | 'python3'
+  | 'ruby'
+  | 'scala'
+  | 'swift'
+  | 'mysql'
+  | 'oracle';
+
+interface ProblemInfo {
+  selectedLanguage: SelectedLanguage;
+  problemId: string;
+}
+
+export { SelectedLanguage, ProblemInfo };


### PR DESCRIPTION
## 구현 사항
- solutionTab의 HTTP 통신 로직들을 custom hook으로 분리
- 문제 id의 풀이들을 service worker와 message passing해 받아오는 getAllSolutions 함수를 service 레이어로 분리