### PR TITLE
refactor: Profile 페이지 컴포넌트의 비즈니스 로직을 Custom Hook으로  분리

### DIFF
--- a/build/webpack.common.js
+++ b/build/webpack.common.js
@@ -30,9 +30,9 @@ module.exports = {
     memoTab: APP_PATH('src/pages/newTab/memo/index.tsx'),
   },
   output: {
-    path: APP_PATH('dist'),
     filename: 'script/[name].js',
-    publicPath: 'dist',
+    publicPath: './',
+    path: APP_PATH('dist'),
   },
   cache: {
     type: env.dev ? 'memory' : 'filesystem',

--- a/src/hooks/profile/index.ts
+++ b/src/hooks/profile/index.ts
@@ -1,0 +1,4 @@
+import { useUserEmail } from './useUserEmail';
+import { useProblems } from './useProblems';
+
+export { useUserEmail, useProblems };

--- a/src/hooks/profile/useProblems.ts
+++ b/src/hooks/profile/useProblems.ts
@@ -1,0 +1,52 @@
+import React from 'react';
+
+import { getAllProblemsList, getSolvedProblemList } from '@src/service/profile';
+import { SolvedProblemType } from '@src/types/profile/profile-layout';
+
+export const useProblems = (userEmail: string) => {
+  const [isLoaded, setIsLoaded] = React.useState(true);
+
+  const [allProblems, setAllSolvedProblems] = React.useState<SolvedProblemType>([]);
+  const [solvedProblems, setSolvedProblems] = React.useState<SolvedProblemType>([]);
+
+  React.useEffect(() => {
+    if (!userEmail) {
+      return;
+    }
+
+    (async () => {
+      await setAllProblemsCallback(setAllSolvedProblems);
+      await setSolvedProblemsCallback({ userEmail, allProblems, setSolvedProblems });
+
+      setIsLoaded(false);
+    })();
+  }, [userEmail, allProblems]);
+
+  return {
+    isLoaded,
+    allProblems,
+    solvedProblems,
+  };
+};
+
+const setAllProblemsCallback = async (
+  setAllSolvedProblems: React.Dispatch<React.SetStateAction<SolvedProblemType>>,
+) => {
+  const allProblems = await getAllProblemsList();
+  setAllSolvedProblems(allProblems);
+};
+
+interface SolvedProblemsCallback {
+  userEmail: string;
+  allProblems: SolvedProblemType;
+  setSolvedProblems: React.Dispatch<React.SetStateAction<SolvedProblemType>>;
+}
+
+const setSolvedProblemsCallback = async ({
+  userEmail,
+  allProblems,
+  setSolvedProblems,
+}: SolvedProblemsCallback) => {
+  const solvedProblems = await getSolvedProblemList(userEmail as string, allProblems);
+  setSolvedProblems(solvedProblems);
+};

--- a/src/hooks/profile/useUserEmail.ts
+++ b/src/hooks/profile/useUserEmail.ts
@@ -1,0 +1,35 @@
+import React from 'react';
+
+import { setUserInfoStorage } from '@src/api/solution/setUserInfoStorage';
+import { getUserEmail } from '@src/api/solution/getUserEmail';
+
+export const useUserEmail = () => {
+  const [isLoggedIn, setIsLoggedIn] = React.useState(true);
+  const [userEmail, setUserEmail] = React.useState<string | undefined>('');
+
+  React.useEffect(() => {
+    setUserEmailCallback({ setIsLoggedIn, setUserEmail });
+  }, []);
+
+  return {
+    isLoggedIn,
+    userEmail,
+  };
+};
+
+interface UserEmailCallback {
+  setIsLoggedIn: React.Dispatch<React.SetStateAction<boolean>>;
+  setUserEmail: React.Dispatch<React.SetStateAction<string | undefined>>;
+}
+
+const setUserEmailCallback = async ({ setIsLoggedIn, setUserEmail }: UserEmailCallback) => {
+  await setUserInfoStorage();
+
+  const userEmail = await getUserEmail();
+  if (!userEmail) {
+    setIsLoggedIn(false);
+    return;
+  }
+
+  setUserEmail(userEmail);
+};

--- a/src/pages/newTab/profile/Problems.tsx
+++ b/src/pages/newTab/profile/Problems.tsx
@@ -9,13 +9,13 @@ import Pagination from '@src/components/shared/section/Pagination';
 import { sortOption } from '@src/store/profile';
 import { BoxStyle } from '@src/styles/global';
 import { ContentHeaderInfoStyle } from '@src/styles/global';
+import { getFilteredSolvedProblems, getPartTitleListOfSolvedProblems } from '@src/service/profile';
 
 import { levelsColor } from '@src/constants/level';
 import { PROBLEM_LIST, SORT_LIST, SORT_TYPE } from '@src/constants/profile';
 import { SOLVING_PROBLEM_URL as BASE_URL } from '@src/constants/url';
 import {
   ProblemType,
-  SolvedProblemProps,
   SortProps,
   SortItemProps,
   SortType,
@@ -23,17 +23,18 @@ import {
   ProblemTableProps,
   ContentProps,
 } from '@src/types/profile/profile-problems';
+import { SolvedProblemType } from '@src/types/profile/profile-layout';
 import Book from '@assets/icons/Book.svg';
 import ArrowUp from '@assets/icons/ArrowUp.svg';
 import ArrowDown from '@assets/icons/ArrowDown.svg';
 import NoContent from '@assets/images/noContent.png';
 import '@src/styles/font.css';
 
-export default function Problems({
-  allSolvedCnt,
-  solvedProblems,
-  partTitleList,
-}: SolvedProblemProps) {
+export default function Problems({ solvedProblems }: { solvedProblems: SolvedProblemType }) {
+  const allSolvedCnt = solvedProblems.length;
+  const filteredSolvedProblems = getFilteredSolvedProblems(solvedProblems);
+  const partTitleList = getPartTitleListOfSolvedProblems(solvedProblems);
+
   const [pageIdx, setPageIdx] = React.useState(0);
   const limit = 10;
   const offset = pageIdx * limit;
@@ -46,8 +47,12 @@ export default function Problems({
         onChangePageIdx={setPageIdx}
         partTitleList={partTitleList}
       />
-      <Problems.Content solvedProblems={solvedProblems}>
-        <Problems.ItemList start={offset} end={offset + limit} solvedProblems={solvedProblems} />
+      <Problems.Content solvedProblems={filteredSolvedProblems}>
+        <Problems.ItemList
+          start={offset}
+          end={offset + limit}
+          solvedProblems={filteredSolvedProblems}
+        />
         <Pagination
           total={solvedProblems.length}
           limit={limit}

--- a/src/pages/newTab/profile/Statistics.tsx
+++ b/src/pages/newTab/profile/Statistics.tsx
@@ -10,24 +10,24 @@ import { Children } from '@src/types/global';
 import { ContentHeaderInfoStyle } from '@src/styles/global';
 import { STATIST_HEAD } from '@src/constants/profile';
 import { levels, levelsColor } from '@src/constants/level';
-
-import {
-  ProblemCntType,
-  DoughnutType,
-  ChartInfo,
-  ChartInfoList,
-} from '@src/types/profile/profile-statistics';
-
 import Chart from '@assets/icons/Chart.svg';
 import '@src/styles/font.css';
 
-interface StatisticsType {
-  problemCnt: ProblemCntType;
-  solvedLevelCnt: number[];
-  chartInfoList: ChartInfoList;
-}
+import { getChartInfoList, getProblemsCnt, getProblemsLevelList } from '@src/service/profile';
 
-export default function Statistics({ problemCnt, solvedLevelCnt, chartInfoList }: StatisticsType) {
+import {
+  DoughnutType,
+  ChartInfo,
+  ChartInfoList,
+  ProblemCntType,
+} from '@src/types/profile/profile-statistics';
+import { ProblemsType } from '@src/types/profile/profile-layout';
+
+export default function Statistics({ allProblems, solvedProblems }: ProblemsType) {
+  const problemCnt = getProblemsCnt({ allProblems, solvedProblems });
+  const solvedLevelCnt = getProblemsLevelList(solvedProblems);
+  const chartInfoList = getChartInfoList({ allProblems, solvedProblems });
+
   return (
     <BoxStyle>
       <Statistics.Header problemCnt={problemCnt} />

--- a/src/pages/newTab/profile/index.tsx
+++ b/src/pages/newTab/profile/index.tsx
@@ -9,72 +9,23 @@ import ProfileTab from './ProfileTab';
 import Problems from './Problems';
 import Statistics from './Statistics';
 
-import { setUserInfoStorage } from '@src/api/solution/setUserInfoStorage';
-import { getUserEmail } from '@src/api/solution/getUserEmail';
-import { SolvedProblemType } from '@src/types/profile/profile-layout';
 import { navOption } from '@src/store/profile';
-import {
-  getAllProblemsList,
-  getChartInfoList,
-  getFilteredSolvedProblems,
-  getPartTitleListOfSolvedProblems,
-  getProblemsCnt,
-  getProblemsLevelList,
-  getSolvedProblemList,
-} from '@src/service/profile';
+import { useUserEmail, useProblems } from '@src/hooks/profile';
 
 const ProfileTabLayout = () => {
-  const [isLoaded, setIsLoaded] = React.useState(true);
-  const [isLoggedIn, setIsLoggedIn] = React.useState(true);
-
-  const [allProblems, setAllSolvedProblems] = React.useState<SolvedProblemType>([]);
-  const [solvedProblems, setSolvedProblems] = React.useState<SolvedProblemType>([]);
+  const { isLoggedIn, userEmail } = useUserEmail();
+  const { isLoaded, allProblems, solvedProblems } = useProblems(userEmail as string);
   const selectedNavOption = useRecoilValue(navOption);
 
-  React.useEffect(() => {
-    (async () => {
-      await setUserInfoStorage();
-
-      const userEmail = await getUserEmail();
-      if (userEmail === undefined) {
-        setIsLoggedIn(false);
-        return;
-      }
-
-      const allProblems = await getAllProblemsList();
-      setAllSolvedProblems(allProblems);
-
-      const solvedProblems = await getSolvedProblemList(userEmail, allProblems);
-      setSolvedProblems(solvedProblems);
-
-      setIsLoaded(false);
-    })();
-  }, []);
-
-  const problemCnt = getProblemsCnt({ allProblems, solvedProblems });
-  const solvedLevelCnt = getProblemsLevelList(solvedProblems);
-  const chartInfoList = getChartInfoList({ allProblems, solvedProblems });
-  const filteredSolvedProblems = getFilteredSolvedProblems(solvedProblems);
-  const partTitleList = getPartTitleListOfSolvedProblems(solvedProblems);
   return (
     <ProfileTab>
       <ProfileTab.Header />
       <ProfileTab.Nav />
       <ProfileTab.Content isLoggedIn={isLoggedIn} isLoaded={isLoaded}>
         {selectedNavOption === 'MAIN' && (
-          <Statistics
-            problemCnt={problemCnt}
-            solvedLevelCnt={solvedLevelCnt}
-            chartInfoList={chartInfoList}
-          />
+          <Statistics allProblems={allProblems} solvedProblems={solvedProblems} />
         )}
-        {selectedNavOption === 'PROBLEM' && (
-          <Problems
-            allSolvedCnt={solvedProblems.length}
-            solvedProblems={filteredSolvedProblems}
-            partTitleList={partTitleList}
-          />
-        )}
+        {selectedNavOption === 'PROBLEM' && <Problems solvedProblems={solvedProblems} />}
       </ProfileTab.Content>
       <ProfileTab.Footer />
     </ProfileTab>

--- a/src/service/profile/getChartInfoList.ts
+++ b/src/service/profile/getChartInfoList.ts
@@ -1,9 +1,9 @@
 import { levels, levelsColor } from '@src/constants/level';
-import { ProblemsCntType } from '@src/types/profile/profile-layout';
+import { ProblemsType } from '@src/types/profile/profile-layout';
 
 import { getProblemsLevelList } from './getProblemsLevelList';
 
-const getChartInfoList = ({ allProblems, solvedProblems }: ProblemsCntType) => {
+const getChartInfoList = ({ allProblems, solvedProblems }: ProblemsType) => {
   const problemsCnt = getProblemsLevelList(allProblems);
   const solvedCnt = getProblemsLevelList(solvedProblems);
 

--- a/src/service/profile/getProblemsCnt.ts
+++ b/src/service/profile/getProblemsCnt.ts
@@ -1,6 +1,6 @@
-import { ProblemsCntType } from '@src/types/profile/profile-layout';
+import { ProblemsType } from '@src/types/profile/profile-layout';
 
-const getProblemsCnt = ({ allProblems, solvedProblems }: ProblemsCntType) => ({
+const getProblemsCnt = ({ allProblems, solvedProblems }: ProblemsType) => ({
   allCnt: allProblems.length,
   solvedCnt: solvedProblems.length,
 });

--- a/src/types/profile/profile-layout.ts
+++ b/src/types/profile/profile-layout.ts
@@ -11,7 +11,7 @@ interface ProblemType {
 
 type SolvedProblemType = ProblemType[];
 
-type ProblemsCntType = {
+type ProblemsType = {
   allProblems: SolvedProblemType;
   solvedProblems: SolvedProblemType;
 };
@@ -42,7 +42,7 @@ type LevelListFunc = (problems: SolvedProblemType) => number[];
 export {
   ProblemType,
   SolvedProblemType,
-  ProblemsCntType,
+  ProblemsType,
   ProblemCntType,
   SortType,
   SelectNameType,

--- a/src/types/profile/profile-problems.ts
+++ b/src/types/profile/profile-problems.ts
@@ -12,52 +12,45 @@ interface ProblemType {
 
 type SolvedProblemType = ProblemType[];
 
-type SolvedProblemProps = {
-  allSolvedCnt: number;
-  solvedProblems: SolvedProblemType;
-  partTitleList: Array<string>;
-};
-
 type SelectNameType = 'level' | 'finishedCount' | 'acceptanceRate';
 
-type SortProps = {
+interface SortProps {
   allSolvedCnt: number;
   onChangePageIdx: (page: number) => void;
   partTitleList: Array<string>;
-};
+}
 
-type SortItemProps = {
+interface SortItemProps {
   item: SelectNameType;
   onChangePageIdx: (page: number) => void;
-};
+}
 
-type SortType = {
+interface SortType {
   [key: string]: string | boolean;
   type: SelectNameType;
   isAscending: SelectSortType;
-};
+}
 
-type SortItemType = {
+interface SortItemType {
   [key: string]: string;
   level: string;
   finishedCount: string;
   acceptanceRate: string;
-};
+}
 
-type ProblemTableProps = {
+interface ProblemTableProps {
   start: number;
   end: number;
   solvedProblems: SolvedProblemType;
-};
+}
 
-type ContentProps = {
+interface ContentProps {
   children: JSX.Element | JSX.Element[];
   solvedProblems: SolvedProblemType;
-};
+}
 
 export {
   ProblemType,
-  SolvedProblemProps,
   SelectNameType,
   SortProps,
   SortItemProps,


### PR DESCRIPTION
## 구현 사항
Profile 페이지 컴포넌트의 비즈니스 로직을 Custom Hook으로  분리

Closes #124 