### PR TITLE
chore: webpack production 번들 크기 최적화

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
       - develop
+    paths-ignore:
+      - '**/*.md'
 
 jobs:
   test:

--- a/Readme.md
+++ b/Readme.md
@@ -9,32 +9,17 @@
 
 [![Chrome Web Store](https://storage.googleapis.com/chrome-gcs-uploader.appspot.com/image/WlD8wC6g8khYWPJUsQceQkhXSlv1/UV4C4ybeBTsZt43U4xis.png)](https://chrome.google.com/webstore/detail/%ED%94%84%EB%A1%9C%EC%86%94%EB%B8%8Cpro-solve/pjffalefhahlellpckbbiehmbljjhihl/related?hl=ko)
 
-## 📜 목차
-
-- [프로솔브(Pro-Solve) ](#프로솔브pro-solve-)
-  - [📜 목차](#-목차)
-  - [✨ 지원 기능](#-지원-기능)
-  - [🎞 동작 화면](#-동작-화면)
-  - [🎨 프로젝트 아키텍처](#-프로젝트-아키텍처)
-  - [💡 왜 만들게 되었나요?](#-왜-만들게-되었나요)
-    - [기능 1. 성공한 문제 차트 \& 표](#기능-1-성공한-문제-차트--표)
-    - [기능 2. 제출한 풀이 저장](#기능-2-제출한-풀이-저장)
-    - [기능 3. 풀이 클립보드](#기능-3-풀이-클립보드)
-  - [🙋‍♀️ 어떻게 사용할 수 있나요?](#️-어떻게-사용할-수-있나요)
-  - [😲 Q\&A](#-qa)
-  - [📚 링크 \& 문서](#-링크--문서)
-
 <br />
 
 ## ✨ 지원 기능
 
 프로솔브는 **크롬 브라우저**에서만 이용할 수 있습니다.
 
-|           **성공한 문제 차트**            |            **성공한 문제 표**             |
-| :---------------------------------------: | :---------------------------------------: |
-| <img src="https://imgur.com/QupH6ua.png"> | <img src="https://imgur.com/5BQfmJh.png"> |
-|               **풀이 저장**               |             **풀이 클립보드**             |
-| <img src="https://imgur.com/pUFGw2U.png"> | <img src="https://imgur.com/DXv3A8N.png"> |
+|                                               **성공한 문제 차트**                                                |                                                **성공한 문제 표**                                                 |
+| :---------------------------------------------------------------------------------------------------------------: | :---------------------------------------------------------------------------------------------------------------: |
+|                                     <img src="https://imgur.com/QupH6ua.png">                                     | <img src="https://user-images.githubusercontent.com/69149030/221437800-d9de3a6b-b299-4b45-9d77-1171fcb97d4e.png"> |
+|                                                   **풀이 저장**                                                   |                                                 **풀이 클립보드**                                                 |
+| <img src="https://user-images.githubusercontent.com/69149030/221437803-66c0c66f-24f2-46bd-bb5e-9f70a51a250b.png"> |                                     <img src="https://imgur.com/DXv3A8N.png">                                     |
 
 <br />
 
@@ -55,20 +40,6 @@ https://user-images.githubusercontent.com/69149030/194714332-ec61e267-1d86-42e3-
 https://user-images.githubusercontent.com/69149030/196757224-1fd436c6-cef2-45b7-931f-d216c19c3ae3.mp4
 
 <p align="center">다른 사람 풀이 페이지의 코드 클립보드</p>
-
-<br />
-
-## 🎨 프로젝트 아키텍처
-
-<img src="https://imgur.com/jCb4Wzw.png" />
-
-- **Presentational-Container**과 **Compound Component** 디자인 패턴을 이용해 프로젝트를 구성했습니다.
-
-- **사용자가 제출한 문제 정보를 저장 및 조회** 기능을 구현하기 위해 **Firebase**를 이용했습니다. <br />
-  유저들을 식별하기 위해 **Firebase Google 소셜 로그인**을 이용하였으며, **Firebase Cloud FireStore**을 이용해 사용자가 제출한 풀이 정보를 저장 및 조회합니다.
-
-- **성공한 문제 차트 & 표** 기능을 구현하기 위해 전체 문제와 유저가 성공한 문제 정보가 필요합니다. <br />
-  문제 정보를 얻기 위해 **GitHub Actions과 jsDelivr, Chrome Storage API**를 이용하였습니다.
 
 <br />
 
@@ -137,3 +108,4 @@ Chart는 유저가 각 레벨 문제들을 전체 중 몇 개(퍼센트) 풀었�
 
 - [전체 문제 저장소](https://github.com/dev-red5/programmers-problems)
 - [개발 회고록](https://velog.io/@dev-redo/%ED%94%84%EB%A1%9C%EC%86%94%EB%B8%8C-%ED%81%AC%EB%A1%AC-%EC%9D%B5%EC%8A%A4%ED%85%90%EC%85%98-%EA%B0%9C%EB%B0%9C-%ED%9B%84%EA%B8%B0)
+- [트러블슈팅](https://zircon-ambulance-d5e.notion.site/cce8099aab50406791681e3387b852d0?v=101c2a5127bf4c1887b23bfd23078901)

--- a/build/optionalPlugin/webpack.bundleAnalyzer.js
+++ b/build/optionalPlugin/webpack.bundleAnalyzer.js
@@ -4,7 +4,6 @@ module.exports = {
   plugins: [
     new BundleAnalyzerPlugin({
       analyzerMode: 'static', // 분석된 결과를 파일로 저장
-      openAnalyzer: false, // 분석 결과 페이지 자동 열기 여부
       reportFilename: `bundle-size.html.html`, // 분석 결과 파일명
       openAnalyzer: true, // 웹팩 빌드 후 보고서파일을 자동으로 열지 여부
     }),

--- a/build/webpack.prod.js
+++ b/build/webpack.prod.js
@@ -41,6 +41,8 @@ module.exports = {
     ],
   },
   optimization: {
+    minimize: true,
+    usedExports: true,
     minimizer: [
       new ESBuildMinifyPlugin({
         target: 'es2015',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prosolve",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "main": "index.js",
   "pretty": "prettier --write \"src/**/*.(ts|tsx)\"",
   "scripts": {

--- a/src/static/manifest.json
+++ b/src/static/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "프로솔브(Pro-Solve)",
   "description": "제출한 모든 프로그래머스 풀이를 확인할 수 있게 해주는 크롬 익스텐션",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "manifest_version": 3,
   "icons": {
     "16": "icon.png",


### PR DESCRIPTION
## 구현 사항
webpack에서 production 환경에서 트리쉐이킹을 진행해 번들 크기를 1.13MB에서 817.58KB로 줄여 약 27.7% 감소